### PR TITLE
fix: import the fractor configuration if found in fractor.php file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "a9f/fractor": "^0.3",
+    "a9f/fractor": "^0.3 || ^0.4",
     "rector/rector": "^1.0",
     "symfony/config": "^6.4 || ^7.0",
     "symfony/console": "^6.4 || ^7.0",

--- a/res/run_fractor.php
+++ b/res/run_fractor.php
@@ -14,9 +14,7 @@ return static function (ContainerConfigurator $configurator) {
     if (!is_string($fractorConfigFile)) {
         throw new \RuntimeException('No file passed in env variable FRACTOR_CONFIG_FILE', 1712507292);
     }
-    $fractorConfigClosure = (require $fractorConfigFile);
-    Assert::isCallable($fractorConfigClosure, 'FRACTOR_CONFIG_FILE did not yield a callable');
-    $fractorConfigClosure($fractorConfig);
+    $fractorConfig->import($fractorConfigFile);
 
     $lifterConfigFile = getenv('LIFTER_CONFIG_FILE');
     if (!is_string($lifterConfigFile)) {


### PR DESCRIPTION
Hi @andreaswolf ,

thanks for the inspiring speech at t3chh .
I just wanted to try out the lifter including fractor and came across the error

```FRACTOR: Fatal error: Uncaught TypeError: a9f\Fractor\Configuration\FractorConfigurationBuilder::__invoke(): Argument #1 ($containerConfigurator) must be of type Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator, a9f\Fractor\Configuration\FractorConfigurationBuilder given, called in /var/www/html/lifter/vendor/a9f/lifter/res/run_fractor.php on line 19 and defined in /var/www/html/lifter/vendor/a9f/fractor/src/Configuration/FractorConfigurationBuilder.php:49```

I change the run_fractor to use import method. Hopefully that should do the trick